### PR TITLE
configure docker environment for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+# composing Docker development environment
+
+version: '3.8'
+
+services:
+  db:
+    build: docker/localized_postgres/.
+    ports: 
+      - 5432:5432
+    environment:
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - db_data:/var/lib/postgresql/data
+
+volumes:
+  db_data:
+
+
+

--- a/docker/localized_postgres/Dockerfile
+++ b/docker/localized_postgres/Dockerfile
@@ -1,0 +1,5 @@
+# Localize postgres for de_DE with UTF-8
+
+FROM postgres:14
+RUN localedef -i de_DE -c -f UTF-8 -A /usr/share/locale/locale.alias de_DE.UTF-8
+ENV LANG de_DE.utf8


### PR DESCRIPTION
Docker is used to set up the development environment. `docker-compose.yaml` defines a PostgreSQL service named `db` to be available at the default postgres port on the local machine. Besides, a __volume__ is set up to __persist postgres db data__ even if the container is removed or recreated.

### Why using a distinct Dockerfile?

The most straight-forward way to use postgres on docker would have been to just state the image in `docker-compose.yml` and having no Dockerfile at all:
```
service:
  db:
    image: postgres:14
```
While this serves well in many cases, I decided to set the locale of my postgres service container to `de_DE.UTF-8`.  See [postgres on DockerHub](https://hub.docker.com/_/postgres) for more details about configuring the postgres docker image.

### What about security and `POSTGRES_PASSWORD`?

Perhaps you remember I said in the README that no sensitive data should enter the git repository. So you might be surprised to find 
```
POSTGRES_PASSWORD: postgres
```
just inside our `docker-compose.yml`. And if you take a look into `config/dev.exs`, you'll find the same configuration setting there. 

IMHO, using the default password used by the phoenix project generator, does not reveal any sensitive information at all. Well, you don't have access to my development machine, and if you have, I'm in trouble anyway. I am a bit pragmatic, and follow the implicit suggestion by the project template to have a convenient compile-time configuration for development but enforcing a more secure runtime configuration for production.

Alternatively, I could configure the app using environment variables (probably using an env_file) to configure both docker and the repository in my app. It is easy to keep them out of the source repository, but you have to provide the environment during development (e.g. by sourcing the .env file). I decided there is not much value to do that procedure here.

### Sensitive data and `/docker-entrypoint-initdb.d`

Connecting a local directory to `/docker-entrypoint-initdb.d` is a convenient way to bootstrap a development database from existing data. But there is one important note here: **Do not put production data (or otherwise sensitive data) in a file or folder that is shared in your source code repository.** 