### PR TITLE
Added scripts to build and deploy image

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
   # Use this service to simulate running the release image on this development system.
   # To make sure PORT configurations are in place, it is not running on port 4000.
   release:
-    image: docker.thorsten-michael.de/tmde:prod
+    image: docker.thorsten-michael.de/tmde:staging
     ports:
       - 8080:8080
     environment:

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+REGISTRY="docker.thorsten-michael.de"
+IMAGE=tmde
+DIR=`dirname "$(readlink -f "$0")"`
+
+docker build -f $DIR/release/Dockerfile -t $REGISTRY/$IMAGE:staging $PWD

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
+# Builds the release image and tags it with :staging, so it can be tested locally
+# and deployed in the production later
 
 REGISTRY="docker.thorsten-michael.de"
 IMAGE=tmde

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# This script tags the current staging image for production and pushes it to the 
+# configured docker repository. After this, it connects to the production server
+# via ssh and pulls the image there. Finally, the running container is recreated.
 
 set -euo pipefail
 IMAGE=tmde
@@ -24,6 +27,7 @@ docker tag $REGISTRY/$IMAGE:staging $REGISTRY/$IMAGE:prod
 docker push $REGISTRY/$IMAGE:prod
 success "production image push to $REGISTRY"
 
+# Login to production server via ssh to pull the updated image and recreate the running container
 ssh $SSH_ARGS 'bash -s' <<-STDIN && success "recreate production container for $DEPLOYMENT_SERVICE on $SERVER" || fail "recreate production container for $DEPLOYMENT_SERVICE on $SERVER"
   set -euo pipefail
   cd $DEPLOYMENT_PATH

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -1,10 +1,11 @@
 #!/bin/bash
 
 set -euo pipefail
-SERVER=thorsten-michael.de
-DEPLOYMENT_PATH=/var/www/thorsten-michael.de
-REGISTRY="docker.$SERVER"
 IMAGE=tmde
+SERVER=thorsten-michael.de
+REGISTRY="docker.$SERVER"
+DEPLOYMENT_PATH=/var/www/thorsten-michael.de
+DEPLOYMENT_SERVICE=$IMAGE
 SSH_OPTIONS="-o StrictHostKeyChecking=no"
 SSH_ARGS="$SERVER $SSH_OPTIONS"
 
@@ -23,11 +24,11 @@ docker tag $REGISTRY/$IMAGE:staging $REGISTRY/$IMAGE:prod
 docker push $REGISTRY/$IMAGE:prod
 success "production image push to $REGISTRY"
 
-ssh $SSH_ARGS 'bash -s' <<-STDIN && success "recreate production container" || fail "recreate production container"
+ssh $SSH_ARGS 'bash -s' <<-STDIN && success "recreate production container for $DEPLOYMENT_SERVICE on $SERVER" || fail "recreate production container for $DEPLOYMENT_SERVICE on $SERVER"
   set -euo pipefail
   cd $DEPLOYMENT_PATH
-  docker compose pull tmde
-  docker compose up -d tmde
+  docker compose pull $DEPLOYMENT_SERVICE
+  docker compose up -d $DEPLOYMENT_SERVICE
 STDIN
 
  

--- a/docker/deploy.sh
+++ b/docker/deploy.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+set -euo pipefail
+SERVER=thorsten-michael.de
+DEPLOYMENT_PATH=/var/www/thorsten-michael.de
+REGISTRY="docker.$SERVER"
+IMAGE=tmde
+SSH_OPTIONS="-o StrictHostKeyChecking=no"
+SSH_ARGS="$SERVER $SSH_OPTIONS"
+
+success () {
+  echo "$1 successful."
+}
+
+fail () {
+  echo "$1 failed."
+  exit 1
+}
+
+echo $PATH
+# Tag current staging image for production and push it to the repository
+docker tag $REGISTRY/$IMAGE:staging $REGISTRY/$IMAGE:prod
+docker push $REGISTRY/$IMAGE:prod
+success "production image push to $REGISTRY"
+
+ssh $SSH_ARGS 'bash -s' <<-STDIN && success "recreate production container" || fail "recreate production container"
+  set -euo pipefail
+  cd $DEPLOYMENT_PATH
+  docker compose pull tmde
+  docker compose up -d tmde
+STDIN
+
+ 
+


### PR DESCRIPTION
Two simple bash scripts related to deploying the release image:

```
docker/build.sh
```
Builds the release image and tags it with `tmde:staging` for testing locally and deploying it later. The docker-compose.yml defining the development environment now uses that :staging tag.

```
docker/deploy.sh
```
Tags the current `tmde:staging` image with `tmde:prod` and pushes it to the configured registry. Then, it connects to the production server with ssh and pulls the image there. Finally, the container is recreated.


