### PR TITLE
11 create the obligatory imprint page

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -53,6 +53,7 @@ config :logger, :console,
 
 # Use Jason for JSON parsing in Phoenix
 config :phoenix, :json_library, Jason
+config :gettext, :default_locale, "de"
 
 # Import environment specific config. This must remain at the bottom
 # of this file so it overrides the configuration defined above.

--- a/content/pages/de/README.md.eex
+++ b/content/pages/de/README.md.eex
@@ -1,0 +1,33 @@
+<!-- INDEX_START -->
+## Motivation
+
+Vielleicht fragst du dich: Warum hast du überhaupt eine persönliche Webseite? Und was steckt dahinter, das Git-Repository öffentlich verfügbar zu machen?
+
+> Das erste Haus baust du für deinen Feind, das zweite für deinen Freund und das dritte für dich selbst
+
+Bisher habe ich keine Häuser gebaut, aber im Laufe der letzten Jahre so einige Webseiten und Anwendungen. Manche davon waren Teil meines Berufes, andere waren für Freunde. Einige Anwendungen dienten als Spielwiese für mich selbst, um ein Gefühl für eine  Programmiersprache, ein neues Framework oder eine Technologie zu bekommen. Dann gab es Projekte, die mir geholfen haben, anstehende Dinge zu erledigen. Vielleicht kennst du das: Man erhofft sich, dass Sie einem bald eine Menge Arbeit abnehmen, aber bis es soweit ist, sind so viele Stunden ins Land gegangen.
+
+Aber bis heute habe ich nie **meine persönliche Webseite** gebaut. Und das aus gutem Grund: Ich wusste nicht, welche Geschichte ich erzählen soll. Es gibt im Web _n_ langweilige Webseiten, die niemanden interessieren (dabei _n_ sei eine ausreichend große Zahl), warum also die Zeit damit verschwenden, das Web mit der Nummer _n+1_ zu bereichern? Das würde die Welt auch nicht besser machen.
+
+Auf der anderen Seite gibt es da draußen so viele professionelle Portfolios von Personen, die Werbung für sich selbst machen. Damit kann und möchte ich nicht konkurrieren. Also habe ich das Erstellen meiner eigenen Webseite verschoben, bis ich etwas **Grundlegendes zu sagen habe** dass mir **wirklich wichtig ist**, **andere weiterbringt**, und **ehrlich über
+mich selber** ist.
+
+Dieser Zeitpunkt ist nun gekommen, und zwar aus folgenden Gründen:
+
+- Ich möchte weiterhin von meinem eigenen Mailserver (...@thorsten-michael.de) E-Mails an meine Freunde senden können, die ihre E-Mail bei T-Online haben.[^1]
+- Ich bin auf der Suche nach einem neuen Job. Das ist natürlich der wichtigere Grund, etwas über mich, meine Kenntnisse und meine Arbeit zu präsentieren.
+
+Deshalb habe ich mich dazu entschlossen, meine eigene Webseite zu bauen, die **das Haus für mich selbst** sein soll, und ganz nebenbei die Geschichte über ihre Konstruktion zu erzählen. Das Repository ist auf GitHub für die Öffentlichkeit zugänglich, damit nicht nur das Ergebnis sichtbar ist, sondern man einen Blick hinter die Kulissen werfen kann: Wie es gebaut ist und welche Überlegungen dahinterstecken. Das ist eine ganz schöne Herausforderung, bietet mir aber
+auch Vorteile:
+
+- ich muss **überlegt vorgehen** und mir **genug Zeit lassen**, da es nicht nur darum geht, etwas schnell zum Laufen zu bringen.
+- ich muss **sorgfältig mit sensiblen Daten umgehen**. Die Anwendung muss offensichtlich so
+entworfen werden, dass geheime Zugangsdaten außerhalb des Quellcodes konfiguriert werden. Eine
+Möglichkeit ist hier, die Konfiguration der Anwendung in Umgebungsvariablen abzulegen, wie in
+[The twelve-factor App](https://12factor.net/config) vorgeschlagen wird.
+
+Macht diese Webseite die Welt wirklich besser? Wahrscheinlich nicht. Bringt sie andere weiter? Mag sein, ich hoffe es zumindest. Auf jeden Fall geht es um etwas Grundlegendes, das mir wirklich wichtig ist.
+
+[^1]: Aus Sicht der Netzneutralität klingt das vielleicht wie ein Scherz: Die Mailserver von T-Online weisen legitime E-Mails von einem Mailserver ab, wenn auf der Domäne
+keine Webseite mit einem ordnungsgemäßen Impressum vorhanden ist. Ein Abuse-Kontakt im WhoIs reicht offensichtlich nicht. Dadurch bin ich gezwungen, meine private Adresse der Öffentlichkeit preiszugeben, was den Datenschutz auf den Kopf stellt. Und natürlich möchte ich keine leere Webseite hosten, nur um ein Impressum zu haben. Am Rande: Sogar DENIC, der Registrar für alle Top-Level ".de" Domains, gibt meine persönlichen Angaben aus Datenschutzgründen nicht preis.
+<!-- INDEX_END -->

--- a/content/pages/de/datenschutzerklärung.md.eex
+++ b/content/pages/de/datenschutzerklärung.md.eex
@@ -1,0 +1,66 @@
+Diese Datenschutzerklärung informiert Sie darüber, wie und warum personenbezogene
+Daten erhoben werden, wenn Sie diese Webseite benutzen.
+
+Der Verantwortliche für diese Website ist:
+
+Thorsten-Michael Deinert\
+Geschwister-Scholl-Str. 13\
+59348 Lüdinghausen\
+[postmaster@thorsten-michael.de](mailto:postmaster@thorsten-michael.de)
+
+Die gesetzlichen Regelungen zum Datenschutz gehen aus der _Europäischen Datenschutzgrundverordnung_ hervor. Das Bundesdatenschutzgesetz (BDSG) und das
+Telemediengesetz (TMG) gelten ergänzend.
+
+Zu den personenbezogenen Daten gehören beispielsweise die IP-Adresse beim Zugriff auf
+die Seite und Ihre E-Mail-Adresse, wenn Sie das Kontaktformular bearbeiten (vgl. Art. 4 DSGVO). Diese Informationen werden gemäß der gesetzlichen Datenschutzbestimmungen auf der Website erhoben und verarbeitet.
+
+## Bereitstellung der Webseite und Zugriffsdaten (Log-Dateien)
+
+Die Webseite erfasst bei jedem Aufruf automatisiert Daten, die Ihr Browser an meinen Server übermittelt. Dabei handelt es sich um folgende Informationen:
+
+- die Request-Zeile, das heißt der Name der angeforderten Seite auf dem Server
+- der Zeitpunkt des Zugriffs
+- der Status-Code der Antwort auf Ihre Anfrage
+- die Menge (Dateigröße) der als Antwort gesendeten Daten
+- Quellseite, also woher auf die angeforderte Seite verwiesen wurde. Das betrifft in erster Linie die Navigation über Links innerhalb dieser Webseite, aber auch, wenn der Zugriff über Suchmaschinen oder andere Portale erfolgt.
+- verwendeter Browser
+- Verwendetes Betriebssystem
+- IP-Adresse
+
+Die Daten werden maximal 7 Tage gespeichert und anschließend gelöscht. Der Speicherung liegt das berechtigte Interesse zugrunde, die Webseite stabil und sicher betreiben zu können, und ggf. Missbrauch verfolgen und aufklären zu können. In einem solchen Fall können die betroffenen Daten bis zur Klärung des Vorfalls gespeichert bleiben.
+
+## Kontaktformular und E-Mail-Kontakt
+
+Wenn Sie die hier angegebenen E-Mail-Adressen oder das Kontaktformular auf dieser Webseite
+nutzen, um mit mir in Kontakt zu treten, werden folgende personenbezogenen Daten gespeichert:
+
+- Ihre E-Mail-Adresse
+- der Inhalt der E-Mail bzw. der Kontaktanfrage auf dem Formular
+- die unter Zugriffsdaten genannten Logging-Informationen, um Missbrauch der Funktionalität
+zu ermöglichen.
+
+Bitte beachten Sie, dass Sie bei der Verwendung von E-Mails selbst dafür verantwortlich sind,
+dass Sie sensitive Daten verschlüsselt übertragen. Das Versenden einer E-Mail entspricht etwa
+dem Versand einer Postkarte – niemand würde darauf seine Bankdaten oder gar PIN verschicken.
+
+Im Gegensatz dazu werden sämtliche Daten, die Sie im Kontaktformular - und auf der gesamten
+Webseite – eingeben, verschlüsselt übertragen. Sie erkennen für gewöhnlich an dem kleinen
+Schloss in der Adresszeile.
+
+## Verwendung von  Cookies
+
+Diese Seite verwendet Cookies, kleine Textdateien, die Ihr Internet-Browser auf Ihrem Endgerät
+speichert. Sie dienen hier ausschließlich der technischen Notwendigkeit, die Sicherheit und
+Funktionalität der Webseite zu gewährleisten. Sie sind Stand der Technik und bedürfen dazu
+keiner Einverständniserklärung Ihrerseits.
+
+Es steht Ihnen jederzeit frei, in Ihrem Browser festzulegen, wie Cookies gespeichert werden.
+Wenn Sie jedoch die Annahme des Session-Cookies verweigern, stehen folgende Funktionen nicht
+oder nur noch eingeschränkt zur Verfügung:
+
+- Kontaktformulare, da Sicherheitsmerkmale bei der Verarbeitung der eingegebenen Daten nicht überprüft werden können
+- Auswahl der Sprache
+
+## Recht auf Auskunft, Löschung und Widerruf
+
+Die Datenschutzgrundverordnung ermöglicht es, unentgeltlich Auskunft über die gespeicherten Daten zu Ihrer Person zu erhalten. Darüber hinaus kann die Löschung, Sperrung oder Berichtigung falscher Daten verlangt werden. Das gilt nur, soweit keine gesetzliche Aufbewahrungspflicht besteht.

--- a/content/pages/de/datenschutzerklärung.md.eex
+++ b/content/pages/de/datenschutzerklärung.md.eex
@@ -1,5 +1,4 @@
-Diese Datenschutzerklärung informiert Sie darüber, wie und warum personenbezogene
-Daten erhoben werden, wenn Sie diese Webseite benutzen.
+Diese Datenschutzerklärung informiert Sie darüber, wie und warum personenbezogene Daten erhoben werden, wenn Sie diese Webseite benutzen.
 
 Der Verantwortliche für diese Website ist:
 
@@ -8,17 +7,15 @@ Geschwister-Scholl-Str. 13\
 59348 Lüdinghausen\
 [postmaster@thorsten-michael.de](mailto:postmaster@thorsten-michael.de)
 
-Die gesetzlichen Regelungen zum Datenschutz gehen aus der _Europäischen Datenschutzgrundverordnung_ hervor. Das Bundesdatenschutzgesetz (BDSG) und das
-Telemediengesetz (TMG) gelten ergänzend.
+Die gesetzlichen Regelungen zum Datenschutz gehen aus der _Europäischen Datenschutzgrundverordnung (DSGVO)_ hervor. Das Bundesdatenschutzgesetz (BDSG) und das Telemediengesetz (TMG) gelten ergänzend.
 
-Zu den personenbezogenen Daten gehören beispielsweise die IP-Adresse beim Zugriff auf
-die Seite und Ihre E-Mail-Adresse, wenn Sie das Kontaktformular bearbeiten (vgl. Art. 4 DSGVO). Diese Informationen werden gemäß der gesetzlichen Datenschutzbestimmungen auf der Website erhoben und verarbeitet.
+Zu den personenbezogenen Daten gehören beispielsweise die IP-Adresse beim Zugriff auf die Seite und Ihre E-Mail-Adresse, wenn Sie das Kontaktformular bearbeiten (vgl. Art. 4 DSGVO). Diese Informationen werden gemäß der gesetzlichen Datenschutzbestimmungen auf der Website erhoben und verarbeitet.
 
 ## Bereitstellung der Webseite und Zugriffsdaten (Log-Dateien)
 
 Die Webseite erfasst bei jedem Aufruf automatisiert Daten, die Ihr Browser an meinen Server übermittelt. Dabei handelt es sich um folgende Informationen:
 
-- die Request-Zeile, das heißt der Name der angeforderten Seite auf dem Server
+- die Request-Zeile, sie beinhaltet unter anderem den Namen und ggf. die Parameter der angeforderten Seite oder Datei auf dem Server
 - der Zeitpunkt des Zugriffs
 - der Status-Code der Antwort auf Ihre Anfrage
 - die Menge (Dateigröße) der als Antwort gesendeten Daten
@@ -31,34 +28,23 @@ Die Daten werden maximal 7 Tage gespeichert und anschließend gelöscht. Der Spe
 
 ## Kontaktformular und E-Mail-Kontakt
 
-Wenn Sie die hier angegebenen E-Mail-Adressen oder das Kontaktformular auf dieser Webseite
-nutzen, um mit mir in Kontakt zu treten, werden folgende personenbezogenen Daten gespeichert:
+Wenn Sie die hier angegebenen E-Mail-Adressen oder das Kontaktformular auf dieser Webseite nutzen, um mit mir in Kontakt zu treten, werden folgende personenbezogenen Daten gespeichert:
 
 - Ihre E-Mail-Adresse
 - der Inhalt der E-Mail bzw. der Kontaktanfrage auf dem Formular
-- die unter Zugriffsdaten genannten Logging-Informationen, um Missbrauch der Funktionalität
-zu ermöglichen.
+- die unter Zugriffsdaten genannten Logging-Informationen, um die Rechtmäßigkeit der Datenverarbeitung nachweisen und Missbrauch der Funktionalität aufklären zu können. Das betrifft insbesondere die IP-Adresse.
 
-Bitte beachten Sie, dass Sie bei der Verwendung von E-Mails selbst dafür verantwortlich sind,
-dass Sie sensitive Daten verschlüsselt übertragen. Das Versenden einer E-Mail entspricht etwa
-dem Versand einer Postkarte – niemand würde darauf seine Bankdaten oder gar PIN verschicken.
+Bitte beachten Sie, dass Sie bei der Verwendung von E-Mails selbst dafür verantwortlich sind, sensitive Daten verschlüsselt zu übertragen. Das Versenden einer E-Mail entspricht dem Versand einer Postkarte – niemand würde darauf seine Bankdaten oder gar PIN verschicken.
 
-Im Gegensatz dazu werden sämtliche Daten, die Sie im Kontaktformular - und auf der gesamten
-Webseite – eingeben, verschlüsselt übertragen. Sie erkennen für gewöhnlich an dem kleinen
-Schloss in der Adresszeile.
+Im Gegensatz dazu werden sämtliche Daten, die Sie im Kontaktformular - und auf der gesamten Webseite – eingeben, verschlüsselt übertragen. Sie erkennen für gewöhnlich an dem kleinen Schloss in der Adresszeile Ihres Browsers.
 
 ## Verwendung von  Cookies
 
-Diese Seite verwendet Cookies, kleine Textdateien, die Ihr Internet-Browser auf Ihrem Endgerät
-speichert. Sie dienen hier ausschließlich der technischen Notwendigkeit, die Sicherheit und
-Funktionalität der Webseite zu gewährleisten. Sie sind Stand der Technik und bedürfen dazu
-keiner Einverständniserklärung Ihrerseits.
+Diese Seite verwendet Cookies, kleine Textdateien, die Ihr Internet-Browser auf Ihrem Endgerät speichert. Sie dienen hier ausschließlich der technischen Notwendigkeit, die Sicherheit und Funktionalität der Webseite zu gewährleisten. Dieser _Session-Cookie_ ist Stand der Technik und bedarf keiner Einverständniserklärung Ihrerseits.
 
-Es steht Ihnen jederzeit frei, in Ihrem Browser festzulegen, wie Cookies gespeichert werden.
-Wenn Sie jedoch die Annahme des Session-Cookies verweigern, stehen folgende Funktionen nicht
-oder nur noch eingeschränkt zur Verfügung:
+Es steht Ihnen jederzeit frei, in Ihrem Browser festzulegen, wie Cookies gespeichert werden. Wenn Sie jedoch die Annahme des Session-Cookie verweigern, stehen folgende Funktionen nicht oder nur eingeschränkt zur Verfügung:
 
-- Kontaktformulare, da Sicherheitsmerkmale bei der Verarbeitung der eingegebenen Daten nicht überprüft werden können
+- Kontaktformulare, da gewisse Sicherheitsmerkmale bei der Verarbeitung der Daten nicht überprüft werden können
 - Auswahl der Sprache
 
 ## Recht auf Auskunft, Löschung und Widerruf

--- a/content/pages/en/privacy_policy.md.eex
+++ b/content/pages/en/privacy_policy.md.eex
@@ -1,0 +1,52 @@
+This privacy policy informs you about how and why your personal data is collected when you use this website.
+
+This website is operated by:
+
+Thorsten-Michael Deinert\
+Geschwister-Scholl-Str. 13\
+59348 Lüdinghausen\
+[postmaster@thorsten-michael.de](mailto:postmaster@thorsten-michael.de)
+
+The legal regulations on data protection are derived from the _General Data Protection Regulation (GDPR)_. 
+
+Personal data includes, for example, your IP address when you access the site and your e-mail address when you process the contact form (cf. Art. 4 GDPR). This information is collected and processed on the website in accordance with the statutory data protection provisions.
+
+## Provision of the website and access data (log files)
+
+The website automatically collects data that your browser transmits on every request. This is the following information:
+
+- the request line, i.e. the name and parameters of the requested page or file on the server
+- the time of the access
+- the status code of the response to your request
+- the amount (file size) of response data
+- source page, i.e. where the requested page was referred to from. This primarily concerns navigation via links within this website, but also if the access is made via search engines or other portals.
+- Browser used
+- Operating system used
+- IP address
+
+The data is stored for a maximum of 7 days and then deleted. The storage is based on the legitimate interest to be able to operate the website in a stable and secure manner and, if necessary, to be able to track and clarify misuse. In such a case, the data concerned may remain stored until the incident has been clarified.
+
+## Contact form and e-mail contact
+
+If you use the e-mail addresses provided here or the contact form on this website to get in touch with me, the following personal data will be stored:
+
+- Your e-mail address
+- the content of the e-mail or the contact request on the form
+- the logging information mentioned under access data, in order to be able to prove the legitimacy of data processing and to clarify misuse of the functionality. In particular, this concerns the IP address
+
+Please note that when using e-mail, you are responsible for transmitting sensitive data in encrypted form. Sending an e-mail is equivalent to sending a postcard - no one would send their bank details or even PIN on it.
+
+In contrast, all the data you enter in the contact form - and on the entire website - is transmitted in encrypted form. You can usually recognize this by the small lock in the address line of your browser.
+
+## Use of cookies
+
+This site uses cookies, small text files that your Internet browser stores on your terminal device. They are used here solely for the technical necessity of ensuring the security and functionality of the website. The _session cookie_ is state of the art and does not require any declaration of consent on your part.
+
+You are always free to set your preferences regarding the storage of cookies in your browser. However, if you refuse to accept the session cookie, the following functions will not be available or will only be available to a limited extent:
+
+- Contact forms, as certain security features cannot be checked when processing the data.
+- Language selection
+
+## Verifying, modifying or deleting information
+
+According to the General Data Protection Regulation, you can request to verify your personal data stored by this website. In addition, the deletion, blocking or correction of incorrect data can be requested. This only applies if there is no legal obligation to retain the data.

--- a/lib/tmde/helper/markdown.ex
+++ b/lib/tmde/helper/markdown.ex
@@ -2,6 +2,24 @@ defmodule Tmde.Helper.Markdown do
   @moduledoc """
   Helper functions to work with markdown files
   """
+  @type filename :: binary()
+  @type html_content :: binary()
+
+  @spec content_to_html!(keyword(filename), keyword) ::
+          keyword(%{path: filename, html: html_content})
+  @doc """
+  given a keyword list of locales and markdown file paths, it converts the markdown files
+  to html and returns a keyword list of %{path: _, html: _} maps for each local file.
+  """
+  def content_to_html!(contents, opts \\ []) do
+    for {lang, path} <- contents do
+      {lang,
+       %{
+         path: path,
+         html: file_to_html!(path, opts)
+       }}
+    end
+  end
 
   @doc """
   Reads a markdown file and converts it to html.
@@ -13,6 +31,7 @@ defmodule Tmde.Helper.Markdown do
     not found.
    - for other options, refer to `Earmark.Options`
   """
+  @spec file_to_html!(filename, keyword) :: html_content
   def file_to_html!(path, opts \\ []) do
     {splitter, opts} = opts |> Keyword.pop(:splitter)
 

--- a/lib/tmde/helper/markdown.ex
+++ b/lib/tmde/helper/markdown.ex
@@ -8,23 +8,44 @@ defmodule Tmde.Helper.Markdown do
 
   Options may contain:
    - `splitter`: A string that uses comment tags to convert only a section of the file. If
-    you provide `splitter: "SPLITTER"`, it will use the content between the tags
-    `<!-- SPLITTER_START -->`and `<!-- SPLITTER_END -->`.
+    you provide `splitter: "SPLIT"`, it will use the content between the tags
+    `<!-- SPLIT_START -->`and `<!-- SPLIT_END -->`. Raises an ´ArgumentError´ if comments
+    not found.
    - for other options, refer to `Earmark.Options`
   """
-  def file_to_html(path, opts \\ []) do
+  def file_to_html!(path, opts \\ []) do
     {splitter, opts} = opts |> Keyword.pop(:splitter)
 
     if splitter do
       path
       |> File.read!()
-      |> String.split("<!-- #{splitter}_START -->")
-      |> Enum.at(1)
-      |> String.split("<!-- #{splitter}_END -->")
-      |> List.first()
+      |> drop_before(splitter)
+      |> drop_after(splitter)
       |> Earmark.as_html!(opts)
     else
-      Earmark.from_file!(path, opts)
+      path
+      |> File.read!()
+      |> Earmark.as_html!(opts)
+
+      # TODO as Earmark.from_file!(path, opts) currently won't work properly
+    end
+  end
+
+  defp drop_before(content, splitter) do
+    comment = "<!-- #{splitter}_START -->"
+
+    case String.split(content, comment) do
+      [_before, content | _rest] -> content
+      _ -> raise ArgumentError, "Splitter '#{comment}' not found in file"
+    end
+  end
+
+  defp drop_after(content, splitter) do
+    comment = "<!-- #{splitter}_END -->"
+
+    case String.split(content, comment) do
+      [content, _after | _rest] -> content
+      _ -> raise ArgumentError, "Splitter '#{comment}' not found in file"
     end
   end
 end

--- a/lib/tmde_web/controllers/page_controller.ex
+++ b/lib/tmde_web/controllers/page_controller.ex
@@ -6,40 +6,30 @@ defmodule TmdeWeb.PageController do
   alias Tmde.Helper.Markdown
 
   # Include part of repo's README as external resource and convert it into html on compile time
+  @readme_contents Markdown.content_to_html!(
+                     [de: "content/pages/de/README.md.eex", en: "README.md"],
+                     splitter: "INDEX",
+                     footnotes: true
+                   )
 
-  @readme_contents [de: "content/pages/de/README.md.eex", en: "README.md"]
-                   |> Enum.map(fn
-                     {lang, file} ->
-                       path = Path.expand(file)
-                       @external_resource path
-                       {lang,
-                        Markdown.file_to_html!(path,
-                          splitter: "INDEX",
-                          footnotes: true
-                        )}
-                   end)
-
-  @privacy_policies [
+  @privacy_policies Markdown.content_to_html!(
                       de: "content/pages/de/datenschutzerklärung.md.eex",
                       en: "content/pages/en/privacy_policy.md.eex"
-                    ]
-                    |> Enum.map(fn
-                      {lang, file} ->
-                        path = Path.expand(file)
+                    )
 
-                        @external_resource path
-                        {lang, Markdown.file_to_html!(path)}
-                    end)
+  for %{path: path} <- Keyword.values(@privacy_policies) ++ Keyword.values(@readme_contents) do
+    @external_resource path
+  end
 
   @doc "Homepage"
   def index(conn, _params) do
-    render(conn, "index.html", readme_content: @readme_contents[:de])
+    render(conn, "index.html", readme_content: @readme_contents[:de].html)
   end
 
   def imprint(conn, _params) do
     render(conn, "imprint.html",
       page_title: gettext("Imprint"),
-      privacy_policy: @privacy_policies[:de]
+      privacy_policy: @privacy_policies[:de].html
     )
   end
 end

--- a/lib/tmde_web/controllers/page_controller.ex
+++ b/lib/tmde_web/controllers/page_controller.ex
@@ -6,15 +6,34 @@ defmodule TmdeWeb.PageController do
   alias Tmde.Helper.Markdown
 
   # Include part of repo's README as external resource and convert it into html on compile time
-  @external_resource Path.expand("README.md")
 
-  @readme_content Markdown.file_to_html(Path.expand("README.md"),
-                    splitter: "INDEX",
-                    footnotes: true
-                  )
+  @readme_contents [de: "content/pages/de/README.md.eex", en: "README.md"]
+                   |> Enum.map(fn
+                     {lang, file} ->
+                       path = Path.expand(file)
+                       @external_resource path
+                       {lang,
+                        Markdown.file_to_html(path,
+                          splitter: "INDEX",
+                          footnotes: true
+                        )}
+                   end)
+
+  @privacy_policies [de: "content/pages/de/datenschutzerklärung.md.eex"]
+                    |> Enum.map(fn
+                      {lang, file} ->
+                        path = Path.expand(file)
+
+                        @external_resource path
+                        {lang, Markdown.file_to_html(path)}
+                    end)
 
   @doc "Homepage"
   def index(conn, _params) do
-    render(conn, "index.html", readme_content: @readme_content)
+    render(conn, "index.html", readme_content: @readme_contents[:de])
+  end
+
+  def imprint(conn, _params) do
+    render(conn, "imprint.html", privacy_policy: @privacy_policies[:de])
   end
 end

--- a/lib/tmde_web/controllers/page_controller.ex
+++ b/lib/tmde_web/controllers/page_controller.ex
@@ -13,7 +13,7 @@ defmodule TmdeWeb.PageController do
                        path = Path.expand(file)
                        @external_resource path
                        {lang,
-                        Markdown.file_to_html(path,
+                        Markdown.file_to_html!(path,
                           splitter: "INDEX",
                           footnotes: true
                         )}
@@ -28,7 +28,7 @@ defmodule TmdeWeb.PageController do
                         path = Path.expand(file)
 
                         @external_resource path
-                        {lang, Markdown.file_to_html(path)}
+                        {lang, Markdown.file_to_html!(path)}
                     end)
 
   @doc "Homepage"

--- a/lib/tmde_web/controllers/page_controller.ex
+++ b/lib/tmde_web/controllers/page_controller.ex
@@ -34,6 +34,9 @@ defmodule TmdeWeb.PageController do
   end
 
   def imprint(conn, _params) do
-    render(conn, "imprint.html", privacy_policy: @privacy_policies[:de])
+    render(conn, "imprint.html",
+      page_title: gettext("Imprint"),
+      privacy_policy: @privacy_policies[:de]
+    )
   end
 end

--- a/lib/tmde_web/controllers/page_controller.ex
+++ b/lib/tmde_web/controllers/page_controller.ex
@@ -19,7 +19,10 @@ defmodule TmdeWeb.PageController do
                         )}
                    end)
 
-  @privacy_policies [de: "content/pages/de/datenschutzerklärung.md.eex"]
+  @privacy_policies [
+                      de: "content/pages/de/datenschutzerklärung.md.eex",
+                      en: "content/pages/en/privacy_policy.md.eex"
+                    ]
                     |> Enum.map(fn
                       {lang, file} ->
                         path = Path.expand(file)

--- a/lib/tmde_web/router.ex
+++ b/lib/tmde_web/router.ex
@@ -18,6 +18,7 @@ defmodule TmdeWeb.Router do
     pipe_through :browser
 
     get "/", PageController, :index
+    get "/impressum", PageController, :imprint
   end
 
   # Other scopes may use custom stacks.

--- a/lib/tmde_web/templates/page/imprint.html.heex
+++ b/lib/tmde_web/templates/page/imprint.html.heex
@@ -1,0 +1,21 @@
+<div class="section">
+  <div class="container">
+    <h1 class="title is-1"><%= gettext("Imprint") %></h1>
+    <h2 class="subtitle is-3"><%= gettext("Contact Information") %></h2>
+    <p>
+      Thorsten-Michael Deinert<br>
+      Geschwister-Scholl-Str. 13<br>
+      59348 Lüdinghausen
+    </p>    
+    <a href="mailto:postmaster@thorsten-michael.de">postmaster@thorsten-michael.de</a>
+  </div>
+</div>
+
+<div class="section">
+  <div class="container">
+    <h2 class="title is-2"><%= gettext("Privacy Policy") %></h2>
+    <div class="content">
+      <%= raw(@privacy_policy) %> 
+    </div>
+  </div>
+</div>

--- a/lib/tmde_web/templates/page/index.html.heex
+++ b/lib/tmde_web/templates/page/index.html.heex
@@ -11,3 +11,4 @@
   </div>
 </section>
 
+

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -1,0 +1,38 @@
+## "msgid"s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove "msgid"s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use "mix gettext.extract --merge" or "mix gettext.merge"
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: de\n"
+"Plural-Forms: nplurals=2\n"
+
+#: lib/tmde_web/templates/page/imprint.html.heex:4
+#, elixir-autogen, elixir-format
+msgid "Contact Information"
+msgstr "Verantwortlich im Sinne des §5 TMG"
+
+#: lib/tmde_web/controllers/page_controller.ex:38
+#: lib/tmde_web/templates/page/imprint.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "Imprint"
+msgstr "Impressum"
+
+#: lib/tmde_web/templates/page/imprint.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Privacy Policy"
+msgstr "Datenschutzerklärung"
+
+#: lib/tmde_web/templates/layout/root.html.heex:8
+#, elixir-autogen, elixir-format
+msgid "Welcome"
+msgstr "Willkommen"
+
+#: lib/tmde_web/templates/page/index.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "Welcome to my personal website"
+msgstr "Willkommen auf meiner Webseite!"

--- a/priv/gettext/de/LC_MESSAGES/errors.po
+++ b/priv/gettext/de/LC_MESSAGES/errors.po
@@ -1,48 +1,40 @@
-## `msgid`s in this file come from POT (.pot) files.
+## "msgid"s in this file come from POT (.pot) files.
 ##
-## Do not add, change, or remove `msgid`s manually here as
+## Do not add, change, or remove "msgid"s manually here as
 ## they're tied to the ones in the corresponding POT file
 ## (with the same domain).
 ##
-## Use `mix gettext.extract --merge` or `mix gettext.merge`
+## Use "mix gettext.extract --merge" or "mix gettext.merge"
 ## to merge POT files into PO files.
 msgid ""
 msgstr ""
-"Language: en\n"
+"Language: de\n"
+"Plural-Forms: nplurals=2\n"
 
-## From Ecto.Changeset.cast/4
 msgid "can't be blank"
 msgstr ""
 
-## From Ecto.Changeset.unique_constraint/3
 msgid "has already been taken"
 msgstr ""
 
-## From Ecto.Changeset.put_change/3
 msgid "is invalid"
 msgstr ""
 
-## From Ecto.Changeset.validate_acceptance/3
 msgid "must be accepted"
 msgstr ""
 
-## From Ecto.Changeset.validate_format/3
 msgid "has invalid format"
 msgstr ""
 
-## From Ecto.Changeset.validate_subset/3
 msgid "has an invalid entry"
 msgstr ""
 
-## From Ecto.Changeset.validate_exclusion/3
 msgid "is reserved"
 msgstr ""
 
-## From Ecto.Changeset.validate_confirmation/3
 msgid "does not match confirmation"
 msgstr ""
 
-## From Ecto.Changeset.no_assoc_constraint/3
 msgid "is still associated with this entry"
 msgstr ""
 
@@ -54,7 +46,6 @@ msgid_plural "should be %{count} character(s)"
 msgstr[0] ""
 msgstr[1] ""
 
-## From Ecto.Changeset.validate_length/3
 msgid "should have %{count} item(s)"
 msgid_plural "should have %{count} item(s)"
 msgstr[0] ""
@@ -80,7 +71,6 @@ msgid_plural "should have at most %{count} item(s)"
 msgstr[0] ""
 msgstr[1] ""
 
-## From Ecto.Changeset.validate_number/3
 msgid "must be less than %{number}"
 msgstr ""
 

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -1,0 +1,37 @@
+## This file is a PO Template file.
+##
+## "msgid"s here are often extracted from source code.
+## Add new translations manually only if they're dynamic
+## translations that can't be statically extracted.
+##
+## Run "mix gettext.extract" to bring this file up to
+## date. Leave "msgstr"s empty as changing them here has no
+## effect: edit them in PO (.po) files instead.
+msgid ""
+msgstr ""
+
+#: lib/tmde_web/templates/page/imprint.html.heex:4
+#, elixir-autogen, elixir-format
+msgid "Contact Information"
+msgstr ""
+
+#: lib/tmde_web/controllers/page_controller.ex:38
+#: lib/tmde_web/templates/page/imprint.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "Imprint"
+msgstr ""
+
+#: lib/tmde_web/templates/page/imprint.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Privacy Policy"
+msgstr ""
+
+#: lib/tmde_web/templates/layout/root.html.heex:8
+#, elixir-autogen, elixir-format
+msgid "Welcome"
+msgstr ""
+
+#: lib/tmde_web/templates/page/index.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "Welcome to my personal website"
+msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -1,0 +1,38 @@
+## "msgid"s in this file come from POT (.pot) files.
+##
+## Do not add, change, or remove "msgid"s manually here as
+## they're tied to the ones in the corresponding POT file
+## (with the same domain).
+##
+## Use "mix gettext.extract --merge" or "mix gettext.merge"
+## to merge POT files into PO files.
+msgid ""
+msgstr ""
+"Language: en\n"
+"Plural-Forms: nplurals=2\n"
+
+#: lib/tmde_web/templates/page/imprint.html.heex:4
+#, elixir-autogen, elixir-format
+msgid "Contact Information"
+msgstr ""
+
+#: lib/tmde_web/controllers/page_controller.ex:38
+#: lib/tmde_web/templates/page/imprint.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "Imprint"
+msgstr ""
+
+#: lib/tmde_web/templates/page/imprint.html.heex:16
+#, elixir-autogen, elixir-format
+msgid "Privacy Policy"
+msgstr ""
+
+#: lib/tmde_web/templates/layout/root.html.heex:8
+#, elixir-autogen, elixir-format
+msgid "Welcome"
+msgstr ""
+
+#: lib/tmde_web/templates/page/index.html.heex:3
+#, elixir-autogen, elixir-format
+msgid "Welcome to my personal website"
+msgstr ""

--- a/priv/gettext/errors.pot
+++ b/priv/gettext/errors.pot
@@ -7,7 +7,6 @@
 ## Run `mix gettext.extract` to bring this file up to
 ## date. Leave `msgstr`s empty as changing them here has no
 ## effect: edit them in PO (`.po`) files instead.
-
 ## From Ecto.Changeset.cast/4
 msgid "can't be blank"
 msgstr ""

--- a/test/support/markdown/bad_splitter.md
+++ b/test/support/markdown/bad_splitter.md
@@ -1,0 +1,13 @@
+# H1
+
+content before
+
+<!-- 1_START -->
+
+## H2
+
+inner content
+
+<!-- 2_END -->
+
+content after

--- a/test/support/markdown/input.md
+++ b/test/support/markdown/input.md
@@ -1,0 +1,13 @@
+# H1
+
+content before
+
+<!-- TEST_START -->
+
+## H2
+
+inner content
+
+<!-- TEST_END -->
+
+content after

--- a/test/tmde/helper/markdown_test.exs
+++ b/test/tmde/helper/markdown_test.exs
@@ -1,0 +1,56 @@
+defmodule Tmde.Helper.MarkdownTest do
+  use ExUnit.Case
+  alias Tmde.Helper.Markdown
+
+  setup_all do
+    %{
+      html_full:
+        "<h1>\nH1</h1>\n<p>\ncontent before</p>\n<!-- TEST_START -->\n<h2>\nH2</h2>\n<p>\ninner content</p>\n<!-- TEST_END -->\n<p>\ncontent after</p>\n",
+      html_splitted: "<h2>\nH2</h2>\n<p>\ninner content</p>\n"
+    }
+  end
+
+  @markdown_file "test/support/markdown/input.md"
+  @bad_splitter_file "test/support/markdown/bad_splitter.md"
+
+  describe "Earmark.from_file!/2" do
+    test "due to a bug, it fails when not reading .eex files with Earmark.from_file!" do
+      assert_raise ArgumentError, ~r/:sys_interface/, fn ->
+        Earmark.from_file!(@markdown_file)
+      end
+    end
+  end
+
+  describe "file_to_html!/2" do
+    test "reads and converts a whole markdown file", %{html_full: output} do
+      result = Markdown.file_to_html!(@markdown_file)
+      assert result == output
+    end
+
+    test "reads and converts content between comments when splitter is provided", %{
+      html_splitted: output
+    } do
+      result = Markdown.file_to_html!(@markdown_file, splitter: "TEST")
+
+      assert result == output
+    end
+
+    test "fails if file is not found" do
+      assert_raise File.Error, fn ->
+        Markdown.file_to_html!("bad_filename.md")
+      end
+    end
+
+    test "fails if splitter is given, but start comment not found in file" do
+      assert_raise ArgumentError, ~r/2_START/, fn ->
+        Markdown.file_to_html!(@bad_splitter_file, splitter: "2")
+      end
+    end
+
+    test "fails if splitter is given, but end comment not found in file" do
+      assert_raise ArgumentError, ~r/1_END/, fn ->
+        Markdown.file_to_html!(@bad_splitter_file, splitter: "1")
+      end
+    end
+  end
+end

--- a/test/tmde/helper/markdown_test.exs
+++ b/test/tmde/helper/markdown_test.exs
@@ -53,4 +53,29 @@ defmodule Tmde.Helper.MarkdownTest do
       end
     end
   end
+
+  describe "content_to_html!/2" do
+    test "given a keyword list of files by locale, returns a keyword list of content by locale",
+         %{
+           html_full: html
+         } do
+      result =
+        Markdown.content_to_html!(
+          de: @markdown_file,
+          en: @bad_splitter_file
+        )
+
+      assert [
+               de: %{path: @markdown_file, html: ^html},
+               en: %{path: @bad_splitter_file}
+             ] = result
+
+      assert result[:de].html != result[:en].html
+    end
+
+    test "delegates splitter and options correctly", %{html_splitted: html} do
+      assert [de: %{html: ^html}] =
+               Markdown.content_to_html!([de: @markdown_file], splitter: "TEST")
+    end
+  end
 end

--- a/test/tmde_web/controllers/page_controller_test.exs
+++ b/test/tmde_web/controllers/page_controller_test.exs
@@ -3,6 +3,13 @@ defmodule TmdeWeb.PageControllerTest do
 
   test "GET /", %{conn: conn} do
     conn = get(conn, "/")
-    assert html_response(conn, 200) =~ "Welcome to Phoenix!"
+    assert html_response(conn, 200) =~ "Willkommen"
+  end
+
+  test "GET /impressum", %{conn: conn} do
+    conn = get(conn, "/impressum")
+    response = html_response(conn, 200)
+    assert response =~ "Thorsten-Michael Deinert"
+    assert response =~ "Impressum"
   end
 end


### PR DESCRIPTION
There it is, the first content. Both index and imprint pages are using the `PageController`. Because they are heavy of static content, this content is provided by markdown files for each language.

To do this in a readable manner, the `Tmde.Helper.Markdown` module is used to transform markdown files into html content. It also combines multiple files into keyword lists containing multiple languages or locales.  Tests and typespecs are added for the helper module.