### PR TITLE
18 add metadata for better seo

### DIFF
--- a/lib/tmde_web.ex
+++ b/lib/tmde_web.ex
@@ -23,6 +23,7 @@ defmodule TmdeWeb do
 
       import Plug.Conn
       import TmdeWeb.Gettext
+      import TmdeWeb.Plugs.Page, only: [set_metadata: 2]
       alias TmdeWeb.Router.Helpers, as: Routes
     end
   end

--- a/lib/tmde_web/controllers/page_controller.ex
+++ b/lib/tmde_web/controllers/page_controller.ex
@@ -4,7 +4,6 @@ defmodule TmdeWeb.PageController do
   """
   use TmdeWeb, :controller
   alias Tmde.Helper.Markdown
-  import TmdeWeb.Plugs.Page, only: [set_metadata: 2]
 
   # Include part of repo's README as external resource and convert it into html on compile time
   @readme_contents Markdown.content_to_html!(

--- a/lib/tmde_web/controllers/page_controller.ex
+++ b/lib/tmde_web/controllers/page_controller.ex
@@ -4,7 +4,7 @@ defmodule TmdeWeb.PageController do
   """
   use TmdeWeb, :controller
   alias Tmde.Helper.Markdown
-  alias TmdeWeb.Plugs.Page
+  import TmdeWeb.Plugs.Page, only: [set_metadata: 2]
 
   # Include part of repo's README as external resource and convert it into html on compile time
   @readme_contents Markdown.content_to_html!(
@@ -24,26 +24,29 @@ defmodule TmdeWeb.PageController do
 
   @doc "Homepage"
   def index(conn, _params) do
-    render(conn, "index.html",
-      page: %Page{
-        description:
-          gettext(
-            "Personal homepage of Thorsten-Michael Deinert. Passionate computer scientist, software developer, and programming languages polyglot."
-          )
-      },
+    conn
+    |> set_metadata(
+      title: "Thorsten-Michael",
+      description:
+        gettext(
+          "Personal homepage of Thorsten-Michael Deinert. Passionate computer scientist, software developer, and programming languages polyglot."
+        )
+    )
+    |> render("index.html",
       readme_content: @readme_contents[:de].html
     )
   end
 
   def imprint(conn, _params) do
-    render(conn, "imprint.html",
-      page_title: gettext("Imprint"),
-      page: %Page{
-        description:
-          gettext(
-            "Imprint and privacy policy for thorsten-michael.de, the personal homepage of Thorsten-Michael Deinert."
-          )
-      },
+    conn
+    |> set_metadata(
+      title: gettext("Imprint"),
+      description:
+        gettext(
+          "Imprint and privacy policy for thorsten-michael.de, the personal homepage of Thorsten-Michael Deinert."
+        )
+    )
+    |> render("imprint.html",
       privacy_policy: @privacy_policies[:de].html,
       cookie_data: conn.req_cookies,
       session_data: get_session(conn),

--- a/lib/tmde_web/controllers/page_controller.ex
+++ b/lib/tmde_web/controllers/page_controller.ex
@@ -4,6 +4,7 @@ defmodule TmdeWeb.PageController do
   """
   use TmdeWeb, :controller
   alias Tmde.Helper.Markdown
+  alias TmdeWeb.Plugs.Page
 
   # Include part of repo's README as external resource and convert it into html on compile time
   @readme_contents Markdown.content_to_html!(
@@ -23,12 +24,26 @@ defmodule TmdeWeb.PageController do
 
   @doc "Homepage"
   def index(conn, _params) do
-    render(conn, "index.html", readme_content: @readme_contents[:de].html)
+    render(conn, "index.html",
+      page: %Page{
+        description:
+          gettext(
+            "Personal homepage of Thorsten-Michael Deinert. Passionate computer scientist, software developer, and programming languages polyglot."
+          )
+      },
+      readme_content: @readme_contents[:de].html
+    )
   end
 
   def imprint(conn, _params) do
     render(conn, "imprint.html",
       page_title: gettext("Imprint"),
+      page: %Page{
+        description:
+          gettext(
+            "Imprint and privacy policy for thorsten-michael.de, the personal homepage of Thorsten-Michael Deinert."
+          )
+      },
       privacy_policy: @privacy_policies[:de].html,
       cookie_data: conn.req_cookies,
       session_data: get_session(conn),

--- a/lib/tmde_web/plugs/page.ex
+++ b/lib/tmde_web/plugs/page.ex
@@ -1,0 +1,12 @@
+defmodule TmdeWeb.Plugs.Page do
+  @moduledoc """
+  Plug that handles metadata for pages
+  """
+
+  defstruct locale: "de",
+            author: "Thorsten-Michael Deinert",
+            description: ""
+
+  ## TODO: Make it a proper plug that takes part in the browser pipeline and add
+  ## helper functions for pipelining conn in controller/live component before render
+end

--- a/lib/tmde_web/plugs/page.ex
+++ b/lib/tmde_web/plugs/page.ex
@@ -3,10 +3,45 @@ defmodule TmdeWeb.Plugs.Page do
   Plug that handles metadata for pages
   """
 
+  import Plug.Conn
+
   defstruct locale: "de",
-            author: "Thorsten-Michael Deinert",
+            author: "",
             description: ""
 
-  ## TODO: Make it a proper plug that takes part in the browser pipeline and add
-  ## helper functions for pipelining conn in controller/live component before render
+  @doc """
+  Sets the default metadata to be used when plug is called in the pipeline
+  """
+  def init(options) do
+    __MODULE__
+    |> struct!(options)
+  end
+
+  @doc """
+  Adds a %Page{} struct to conn assignments with key :page, so it is safe to use @page
+  in all the templates (and layouts!) when Plugs.Page is part of the pipeline. Uses
+  the defaults given to init/1, so it can configured inside the pipeline
+  """
+  def call(conn, options) do
+    conn
+    |> assign(:page, options)
+  end
+
+  @doc """
+  Adds a :page_title to the conn assigns. Note that :page_title is a special-purpuse
+  assignment so that it can be manipulated from a socket in LiveView, too
+  """
+  def set_title(conn, nil), do: conn
+  def set_title(conn, title), do: conn |> assign(:page_title, title)
+
+  @doc """
+  Assigns the metadata for this page to the conn. You can use `title: "Title..."` for setting
+  the page title, it is mapped to `set_title/2`. All other metadata is used to update the
+  current :page assignment, which is a %Page{} struct by default.
+  """
+  def set_metadata(conn, page_data \\ []) do
+    conn
+    |> set_title(page_data[:title])
+    |> assign(:page, conn.assigns.page |> struct(page_data))
+  end
 end

--- a/lib/tmde_web/router.ex
+++ b/lib/tmde_web/router.ex
@@ -1,5 +1,6 @@
 defmodule TmdeWeb.Router do
   use TmdeWeb, :router
+  alias TmdeWeb.Plugs
 
   pipeline :browser do
     plug :accepts, ["html"]
@@ -8,6 +9,11 @@ defmodule TmdeWeb.Router do
     plug :put_root_layout, {TmdeWeb.LayoutView, :root}
     plug :protect_from_forgery
     plug :put_secure_browser_headers
+
+    plug Plugs.Page,
+      locale: Application.get_env(:gettext, :default_locale),
+      author: "Thorsten-Michael Deinert",
+      description: "Persönliche Homepage von Thorsten-Michael Deinert."
   end
 
   pipeline :api do

--- a/lib/tmde_web/templates/layout/root.html.heex
+++ b/lib/tmde_web/templates/layout/root.html.heex
@@ -1,8 +1,10 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang={@page.locale}>
   <head>
     <meta charset="utf-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge"/>
+    <meta name="author" content={@page.author}>
+    <meta name="description" content={@page.description}>
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
     <meta name="csrf-token" content={csrf_token_value()}>
     <%= live_title_tag assigns[:page_title] || gettext("Welcome"), suffix: " · thorsten-michael.de" %>

--- a/priv/gettext/de/LC_MESSAGES/default.po
+++ b/priv/gettext/de/LC_MESSAGES/default.po
@@ -16,7 +16,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr "Verantwortlich im Sinne des §5 TMG"
 
-#: lib/tmde_web/controllers/page_controller.ex:31
+#: lib/tmde_web/controllers/page_controller.ex:40
 #: lib/tmde_web/templates/layout/footer.html.heex:14
 #: lib/tmde_web/templates/page/imprint.html.heex:3
 #, elixir-autogen, elixir-format
@@ -28,7 +28,7 @@ msgstr "Impressum"
 msgid "Privacy Policy"
 msgstr "Datenschutzerklärung"
 
-#: lib/tmde_web/templates/layout/root.html.heex:8
+#: lib/tmde_web/templates/layout/root.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Welcome"
 msgstr "Willkommen"
@@ -77,3 +77,13 @@ msgstr "Seite nicht gefunden"
 #, elixir-autogen, elixir-format
 msgid "Sorry, the page does not exist."
 msgstr "Es tut mir leid, die Seite gibt es nicht."
+
+#: lib/tmde_web/controllers/page_controller.ex:43
+#, elixir-autogen, elixir-format
+msgid "Imprint and privacy policy for thorsten-michael.de, the personal homepage of Thorsten-Michael Deinert."
+msgstr "Impressum und Datenschutzerklärung auf thorsten-michael.de, der persönlichen Homepage von Thorsten-Michael Deinert."
+
+#: lib/tmde_web/controllers/page_controller.ex:30
+#, elixir-autogen, elixir-format
+msgid "Personal homepage of Thorsten-Michael Deinert. Passionate computer scientist, software developer, and programming languages polyglot."
+msgstr "Persönliche Homepage von Thorsten-Michael Deinert. Leidenschaftlicher Informatiker, Softwareentwickler und Programmiersprachen-Polyglott."

--- a/priv/gettext/default.pot
+++ b/priv/gettext/default.pot
@@ -15,7 +15,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/tmde_web/controllers/page_controller.ex:31
+#: lib/tmde_web/controllers/page_controller.ex:40
 #: lib/tmde_web/templates/layout/footer.html.heex:14
 #: lib/tmde_web/templates/page/imprint.html.heex:3
 #, elixir-autogen, elixir-format
@@ -27,7 +27,7 @@ msgstr ""
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/tmde_web/templates/layout/root.html.heex:8
+#: lib/tmde_web/templates/layout/root.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Welcome"
 msgstr ""
@@ -75,4 +75,14 @@ msgstr ""
 #: lib/tmde_web/templates/error/404.html.eex:35
 #, elixir-autogen, elixir-format
 msgid "Sorry, the page does not exist."
+msgstr ""
+
+#: lib/tmde_web/controllers/page_controller.ex:43
+#, elixir-autogen, elixir-format
+msgid "Imprint and privacy policy for thorsten-michael.de, the personal homepage of Thorsten-Michael Deinert."
+msgstr ""
+
+#: lib/tmde_web/controllers/page_controller.ex:30
+#, elixir-autogen, elixir-format
+msgid "Personal homepage of Thorsten-Michael Deinert. Passionate computer scientist, software developer, and programming languages polyglot."
 msgstr ""

--- a/priv/gettext/en/LC_MESSAGES/default.po
+++ b/priv/gettext/en/LC_MESSAGES/default.po
@@ -16,7 +16,7 @@ msgstr ""
 msgid "Contact Information"
 msgstr ""
 
-#: lib/tmde_web/controllers/page_controller.ex:31
+#: lib/tmde_web/controllers/page_controller.ex:40
 #: lib/tmde_web/templates/layout/footer.html.heex:14
 #: lib/tmde_web/templates/page/imprint.html.heex:3
 #, elixir-autogen, elixir-format
@@ -28,7 +28,7 @@ msgstr ""
 msgid "Privacy Policy"
 msgstr ""
 
-#: lib/tmde_web/templates/layout/root.html.heex:8
+#: lib/tmde_web/templates/layout/root.html.heex:10
 #, elixir-autogen, elixir-format
 msgid "Welcome"
 msgstr ""
@@ -76,4 +76,14 @@ msgstr ""
 #: lib/tmde_web/templates/error/404.html.eex:35
 #, elixir-autogen, elixir-format
 msgid "Sorry, the page does not exist."
+msgstr ""
+
+#: lib/tmde_web/controllers/page_controller.ex:43
+#, elixir-autogen, elixir-format
+msgid "Imprint and privacy policy for thorsten-michael.de, the personal homepage of Thorsten-Michael Deinert."
+msgstr ""
+
+#: lib/tmde_web/controllers/page_controller.ex:30
+#, elixir-autogen, elixir-format
+msgid "Personal homepage of Thorsten-Michael Deinert. Passionate computer scientist, software developer, and programming languages polyglot."
 msgstr ""


### PR DESCRIPTION
Metadata for a page is handled by `TmdeWeb.Plugs.Page`. It is a Plug that ensures :page is assigned to the conn and can be used safely in templates.
It also defines `set_title/2` and `set_metadata` helper functions to assign metadata conveniently in a pipeline before rendering. They are imported in `TmdeWeb.controller/0` to be available in every controller.

TODO: Test Plug 